### PR TITLE
inlinks() and outlinks()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,20 @@
 # hide password!
+# sorry these can't be committed as they stand.
 isi_rip.logined.sh
+test_*.py
 
 # backups
 *~
 
-*.txt
-*.csv
 # hide our data files
 # (these are paywalled!!)
+*.ciw
 *.isi
- #Derived from .isi
+*.txt
+*.csv
 
 # hide processed output
+# derived from data files
 *.graphml
 *.gephi
 

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ isi_rip.logined.sh
 # hide our data files
 # (these are paywalled!!)
 *.isi
+#Derived from .isi
+*.csv
 
 
 #-------------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,12 @@ isi_rip.logined.sh
 # backups
 *~
 
+# hide our data files
+# (these are paywalled!!)
+*.isi
 
 
+#-------------------------------------------------------
 # Github Python Defaults:
 
 # Byte-compiled / optimized / DLL files

--- a/.gitignore
+++ b/.gitignore
@@ -4,11 +4,17 @@ isi_rip.logined.sh
 # backups
 *~
 
+*.txt
+*.csv
 # hide our data files
 # (these are paywalled!!)
 *.isi
-#Derived from .isi
-*.csv
+ #Derived from .isi
+
+# hide processed output
+*.graphml
+*.gephi
+
 
 
 #-------------------------------------------------------

--- a/CountryCounts.py
+++ b/CountryCounts.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 import papers
 import os
 import csv
@@ -74,10 +76,13 @@ def csvLocCounter(plst, csvf):
         try:
             pdict[csvHeader[0]] = p['UT'][0]
             pdict[csvHeader[1]] = p['PY'][0]
-            try:
-                 pdict[csvHeader[1]] += ' ' + p['PD'][0]
-            except KeyError as e:
-                pass
+            if 'PD' in p:
+                # "PD", "published date", sometimes contains a date but more often contains only a month
+                # occasionally it contains a month range: MON-MON
+                # this is a giant pain, so just coerce to the first month mentioned
+                # *sometimes* it is missing entirely too
+                # TODO: find an ISI documentation reference for this format.
+                pdict[csvHeader[1]] += ' ' + p['PD'][0][:3]
             rp = p['RP'][0].split(',')
             pdict[csvHeader[2]] = rp[0] + ',' + rp[1][:-17]
             pdict[csvHeader[3]] = rp[-1][1:-1] if rp[-1][-4:-1] != 'USA' else 'USA'
@@ -92,7 +97,7 @@ if __name__ == '__main__':
         print outfile +  " already exists\nexisting"
         sys.exit()
         #os.remove(outfile)
-    flist = [f for f in os.listdir(".") if f.endswith(".isi")]
+    flist = sys.argv[1:] if sys.argv[1:] else [f for f in os.listdir(".") if f.endswith(".isi")]
     if len(flist) == 0:
         #checks for any valid files
         print "No isi Files"

--- a/CountryCounts.py
+++ b/CountryCounts.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python2
+#Written by Reid McIlroy-Young
+
 
 import papers
 import os
 import csv
 import sys
+import IPython
 
-csvHeader = ['Paper ID', 'Date','RP-Author', 'RP-Country']#, 'Author', 'Author-Country', 'Subjects']
+csvHeader = ['Paper ID', 'Date', 'Subjects', 'RP-Author', 'RP-Country', 'Author', 'Author-Country']
 
 outfile = "LocationCounts.csv"
 
+SubjectTag = 'SC'
+
+ErrorPrinting = True
+WarningPrinting = False
+
+FileSuffix = '.isi'
 
 class BadPaper(Warning):
     pass
@@ -40,7 +49,7 @@ def isiParser(isifile):
     """
     f = open(isifile, 'r')
     if "VR 1.0" not in f.readline() and "VR 1.0" not in f.readline():
-        raise BadPaper(file + " Does not have a valid header")
+        raise BadPaper(isifile + " Does not have a valid header")
     notEnd = True
     plst = []
     while notEnd:
@@ -70,47 +79,155 @@ def isiParser(isifile):
     finally:
         return plst
 
+def mapAuthorsInstitute(s):
+    """
+    mapAuthorsInstitute takes in a author location string and returns a dict of
+    the authors and their locations. The location will be the same for all.
+    """
+    ls = s[1:].split(']', 1)
+    if len(ls) == 0:
+        raise IndexError
+    authors = ls[0].split('; ')
+    institute = ls[1]
+    return zip(authors, [institute * len(authors)])
+
+def americaIsSpecial(s):
+    """
+    USA country format is unique this deals with it
+    """
+    if s[-4:-1] == 'USA':
+        return 'USA'
+    else:
+        return s[1:-1]
+
 def csvLocCounter(plst, csvf):
+    """
+    csvLocCounter takes in a parsed paper list and a csv file to write, for each 
+    author in each paper it writes a row in the csv file.
+    The row contains the stuff in csvHeader.
+    Most of the function deals with isi's inconsistencies, as such the validity
+    of locations in particular is less than ideal
+    csvLocCounter returns the number of imperfect records it found and could not
+    deal with.
+    """
     pdict = {}
+    ec = 0
     for p in plst:
         try:
-            pdict[csvHeader[0]] = p['UT'][0]
-            pdict[csvHeader[1]] = p['PY'][0]
+            if 'UT' in p:
+                pdict[csvHeader[0]] = p['UT'][0]
+            else:
+                if ErrorPrinting:
+                    print "WOS number error, no field:",
+                raise Warning
+            if 'PY' in p:
+                pdict[csvHeader[1]] = p['PY'][0]
+            else:
+                if ErrorPrinting:
+                    print "Year error, no field:",
+                    print p['UT'][0]
+                raise Warning
             if 'PD' in p:
-                # "PD", "published date", sometimes contains a date but more often contains only a month
-                # occasionally it contains a month range: MON-MON
-                # this is a giant pain, so just coerce to the first month mentioned
-                # *sometimes* it is missing entirely too
-                # TODO: find an ISI documentation reference for this format.
                 pdict[csvHeader[1]] += ' ' + p['PD'][0][:3]
-            rp = p['RP'][0].split(',')
-            pdict[csvHeader[2]] = rp[0] + ',' + rp[1][:-17]
-            pdict[csvHeader[3]] = rp[-1][1:-1] if rp[-1][-4:-1] != 'USA' else 'USA'
-            csvf.writerow(pdict)
-        except KeyError as e:
-            print p.keys()
-
+            if SubjectTag in p:
+                pdict[csvHeader[2]] = p[SubjectTag][0]
+            else:
+                if ErrorPrinting:
+                    print SubjectTag + " error, no year field:",
+                    print p['UT'][0]
+                raise Warning
+            if 'RP' in p:
+                rp = p['RP'][0].split(',')
+                pdict[csvHeader[3]] = rp[0] + ',' + rp[1][:-17]
+                pdict[csvHeader[4]] = americaIsSpecial(rp[-1])
+            else:
+                if 'AF' and 'C1' in p:
+                    pdict[csvHeader[3]] = p['AF'][0]
+                    pdict[csvHeader[4]] = americaIsSpecial(p['C1'][0].split(', ')[-1])
+                else:
+                    if ErrorPrinting:
+                        print "No Locations found in:",
+                        print p['UT'][0]
+                    raise Warning
+            if 'AF' in p:
+                if 'C1' in p:
+                    if p['C1'][0][0] != '[':
+                        for i in range(0, len(p['AF'])):
+                            try:
+                                pdict[csvHeader[5]] = p['AF'][i]
+                            except KeyError as e:
+                                if ErrorPrinting:
+                                    print "Authors error no author list:",
+                                    print p['UT'][0]
+                            if i >= len(p['C1']):
+                                inloc = p['C1'][0]
+                            else:
+                                inloc = p['C1'][i]
+                            pdict[csvHeader[6]] = americaIsSpecial(inloc.split(', ')[-1])
+                            csvf.writerow(pdict)                    
+                    else:
+                        condict = {}
+                        for con in p['C1']:
+                            try:
+                                condict.update(mapAuthorsInstitute(con))
+                            except IndexError as e:
+                                if WarningPrinting:
+                                  print "Institute list wonky potential error in:",
+                                  print p['UT'][0]
+                        for auth in p['AF']:
+                            pdict[csvHeader[5]] = auth
+                            if auth in condict:
+                                inloc = condict[auth]
+                            else:
+                                inloc = p['C1'][0]
+                            pdict[csvHeader[6]] = americaIsSpecial(inloc.split(',')[-1])
+                            csvf.writerow(pdict)
+                else:
+                    if ErrorPrinting:
+                        print "Author Address error, no field:",
+                        print p['UT'][0]
+                    raise Warning
+            else:
+                if ErrorPrinting:
+                    print "Author names error, no field:",
+                    print p['UT'][0]
+                raise Warning
+        except Warning as w:
+            ec +=1
+    return ec
 
 if __name__ == '__main__':
     if os.path.isfile(outfile):
-        #Checks if the output csv already exists and terminates if so
+        #Checks if the output outfile already exists and terminates if so
         print outfile +  " already exists\nexisting"
         sys.exit()
         #os.remove(outfile)
-    flist = sys.argv[1:] if sys.argv[1:] else [f for f in os.listdir(".") if f.endswith(".isi")]
+    flist = sys.argv[1:] if sys.argv[1:] else [f for f in os.listdir(".") if f.endswith(FileSuffix)]
     if len(flist) == 0:
         #checks for any valid files
-        print "No isi Files"
+        print "No " + FileSuffix + " Files"
         sys.exit()
     else:
         #Tells how many files were found
-        print "Found " + str(len(flist)) + " isi files"
+        print "Found " + str(len(flist)) + FileSuffix + "  files"
     csvOut= csv.DictWriter(open(outfile, 'w'), csvHeader, quotechar='"', quoting=csv.QUOTE_ALL)
     csvOut.writeheader()
+    errorsFound = []
     for isi in flist:
-        try:
-            csvLocCounter(isiParser(isi), csvOut)
-        except Exception, e:
-            print type(e)
-            print e
+            try:
+                if ErrorPrinting:
+                    print "Reading " + isi
+                errorsFound.append((csvLocCounter(isiParser(isi), csvOut), isi))
+            except BadPaper as b:
+                print b
+            except Exception, e:
+                print type(e)
+                print e
+    tot = 0
+    for er in errorsFound:
+        print str(er[0]) + " errors found in " + er[1]
+        tot += er[0]
+    print str(tot) + " total errors found"
+    if not ErrorPrinting:
+        print "turn on ErrorPrinting to see more information"
     print "Done"

--- a/CountryCounts.py
+++ b/CountryCounts.py
@@ -1,0 +1,111 @@
+import papers
+import os
+import csv
+import sys
+
+csvHeader = ['Paper ID', 'Date','RP-Author', 'RP-Country']#, 'Author', 'Author-Country', 'Subjects']
+
+outfile = "LocationCounts.csv"
+
+
+class BadPaper(Warning):
+    pass
+
+def paperParser(paper):
+    """
+    paperParser reads paper until it reaches 'EF' for each field tag it adds an
+    entry to the returned dict with the tag as the key and a list of the entries
+    for the tag as the value, the list has each line as an entry.   
+    """
+    tdict = {}
+    currentTag = ''
+    for l in paper:
+        if 'ER' in l[:2]:
+            return tdict
+        elif '   ' in l[:3]: #the string is three spaces in row
+            tdict[currentTag].append(l[3:-1])
+        elif l[2] == ' ':
+            currentTag = l[:2]
+            tdict[currentTag] = [l[3:-1]]
+        else:
+            raise BadPaper("Field tag not formed correctly: " + l)
+    raise BadPaper("End of file reached before EF")
+
+def isiParser(isifile):
+    """
+    isiParser reads a file, checks that the header is correct then reads each
+    paper returning a list of of dicts keyed with the field tags.
+    """
+    f = open(isifile, 'r')
+    if "VR 1.0" not in f.readline() and "VR 1.0" not in f.readline():
+        raise BadPaper(file + " Does not have a valid header")
+    notEnd = True
+    plst = []
+    while notEnd:
+        l = f.next()
+        if not l:
+            raise BadPaper("No ER found in " + isifile)
+        elif l.isspace():
+            continue
+        elif 'EF' in l[:2]:
+            notEnd = False
+            continue
+        else:
+            try:
+                if l[:2] != 'PT':
+                    raise BadPaper("Paper does not start with PT tag")
+                plst.append(paperParser(f))
+                plst[-1][l[:2]] = l[3:-1]
+            except Warning as w:
+                raise BadPaper(str(w.message) + "In " + isifile)
+            except Exception as e:
+                 raise e
+    try:
+        f.next()
+        print "EF not at end of " + isifile
+    except StopIteration as e:
+        pass
+    finally:
+        return plst
+
+def csvLocCounter(plst, csvf):
+    pdict = {}
+    for p in plst:
+        try:
+            pdict[csvHeader[0]] = p['UT'][0]
+            pdict[csvHeader[1]] = p['PY'][0]
+            try:
+                 pdict[csvHeader[1]] += ' ' + p['PD'][0]
+            except KeyError as e:
+                pass
+            rp = p['RP'][0].split(',')
+            pdict[csvHeader[2]] = rp[0] + ',' + rp[1][:-17]
+            pdict[csvHeader[3]] = rp[-1][1:-1] if rp[-1][-4:-1] != 'USA' else 'USA'
+            csvf.writerow(pdict)
+        except KeyError as e:
+            print p.keys()
+
+
+if __name__ == '__main__':
+    if os.path.isfile(outfile):
+        #Checks if the output csv already exists and terminates if so
+        print outfile +  " already exists\nexisting"
+        sys.exit()
+        #os.remove(outfile)
+    flist = [f for f in os.listdir(".") if f.endswith(".isi")]
+    if len(flist) == 0:
+        #checks for any valid files
+        print "No isi Files"
+        sys.exit()
+    else:
+        #Tells how many files were found
+        print "Found " + str(len(flist)) + " isi files"
+    csvOut= csv.DictWriter(open(outfile, 'w'), csvHeader, quotechar='"', quoting=csv.QUOTE_ALL)
+    csvOut.writeheader()
+    for isi in flist:
+        try:
+            csvLocCounter(isiParser(isi), csvOut)
+        except Exception, e:
+            print type(e)
+            print e
+    print "Done"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Nick <nick@kousu.ca>
+Copyright (c) 2015 Nick <nick@kousu.ca>, Reid McIlroy-Young <reid@reidmcy.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ ISI Tools
 ===========
 
 These are a bunch of tools for dealing with the ISI Web of Science.
-You can use them to extract, clean, and process article records in the [ISI Flat File format](TODO)..
+You can use them to extract, clean, and process article records in the [ISI Flat File format](TODO).
 
 Some examples of the sorts of work that can be done with this data:
 * Kieran Healy: [Gender and Citation](http://kieranhealy.org/blog/archives/2015/02/25/gender-and-citation-in-four-general-interest-philosophy-journals-1993-2013/)

--- a/contry-country.py
+++ b/contry-country.py
@@ -36,7 +36,7 @@ def isiParser(isifile):
     """
     f = open(isifile, 'r')
     if "VR 1.0" not in f.readline() and "VR 1.0" not in f.readline():
-        raise BadPaper(file + " Does not have a valid header")
+        raise BadPaper(isifile + " Does not have a valid header")
     notEnd = True
     plst = []
     while notEnd:
@@ -102,7 +102,6 @@ if __name__ == '__main__':
     else:
         #Tells how many files were found
         print "Found " + str(len(flist)) + " txt files"
-
     G = nx.Graph()
     for isi in flist:
         try:
@@ -111,5 +110,6 @@ if __name__ == '__main__':
             print type(e)
             print isi
             print e
+            break
     nx.write_graphml(G, outfile)
     print "Done"

--- a/contry-country.py
+++ b/contry-country.py
@@ -1,0 +1,115 @@
+import papers
+import os
+import csv
+import sys
+import networkx as nx
+
+outfile = "c-c.graphml"
+
+class BadPaper(Warning):
+    pass
+
+def paperParser(paper):
+    """
+    paperParser reads paper until it reaches 'EF' for each field tag it adds an
+    entry to the returned dict with the tag as the key and a list of the entries
+    for the tag as the value, the list has each line as an entry.   
+    """
+    tdict = {}
+    currentTag = ''
+    for l in paper:
+        if 'ER' in l[:2]:
+            return tdict
+        elif '   ' in l[:3]: #the string is three spaces in row
+            tdict[currentTag].append(l[3:-1])
+        elif l[2] == ' ':
+            currentTag = l[:2]
+            tdict[currentTag] = [l[3:-1]]
+        else:
+            raise BadPaper("Field tag not formed correctly: " + l)
+    raise BadPaper("End of file reached before EF")
+
+def isiParser(isifile):
+    """
+    isiParser reads a file, checks that the header is correct then reads each
+    paper returning a list of of dicts keyed with the field tags.
+    """
+    f = open(isifile, 'r')
+    if "VR 1.0" not in f.readline() and "VR 1.0" not in f.readline():
+        raise BadPaper(file + " Does not have a valid header")
+    notEnd = True
+    plst = []
+    while notEnd:
+        l = f.next()
+        if not l:
+            raise BadPaper("No ER found in " + isifile)
+        elif l.isspace():
+            continue
+        elif 'EF' in l[:2]:
+            notEnd = False
+            continue
+        else:
+            try:
+                if l[:2] != 'PT':
+                    raise BadPaper("Paper does not start with PT tag")
+                plst.append(paperParser(f))
+                plst[-1][l[:2]] = l[3:-1]
+            except Warning as w:
+                raise BadPaper(str(w.message) + "In " + isifile)
+            except Exception as e:
+                 raise e
+    try:
+        f.next()
+        print "EF not at end of " + isifile
+    except StopIteration as e:
+        pass
+    finally:
+        return plst
+
+def graphAdder(plst, grph):
+    for p in plst:
+        try:
+            for loc1 in p['C1']:
+                c1 = loc1.split(',')[-1][:-1]
+                if c1[-3:] == 'USA':
+                    c1 = 'USA'
+                if not grph.has_node(c1):
+                    grph.add_node(c1)
+                for loc2 in p['C1'][p['C1'].index(loc1) + 1:]:
+                    c2 = loc2.split(',')[-1][:-1]
+                    if c2[-3:] == 'USA':
+                        c2 = 'USA'
+                    if grph.has_edge(c1, c2):
+                        print str(c1) + ' - ' + str(c2)
+                        grph[c1][c2]['weight'] += 1
+                    else:
+                        grph.add_edge(c1, c2, weight = 1)
+        except KeyError as e:
+            print "Key Error"
+            print p.keys()
+
+if __name__ == '__main__':
+    if os.path.isfile(outfile):
+        #Checks if the output csv already exists and terminates if so
+        print outfile +  " already exists\nexisting"
+        #sys.exit()
+        os.remove(outfile)
+    flist = [f for f in os.listdir(".") if f.endswith(".isi")]
+    if len(flist) == 0:
+        #checks for any valid files
+        print "No txt Files"
+        sys.exit()
+    else:
+        #Tells how many files were found
+        print "Found " + str(len(flist)) + " txt files"
+
+    G = nx.Graph()
+    for isi in flist:
+        try:
+            graphAdder(isiParser(isi), G)
+        except Exception, e:
+            print type(e)
+            print isi
+            print e
+    nx.write_graphml(G, outfile)
+    print "Done"

--- a/httputil.py
+++ b/httputil.py
@@ -1,0 +1,120 @@
+"""
+supporting routines for isi_scrape
+
+"""
+
+import logging
+
+from urllib.parse import urlparse, urlunparse, quote as urlquote, parse_qsl, urljoin
+
+import requests
+from requests.exceptions import HTTPError
+
+def qs_parse(s):
+    """
+    the parse_qs in urllib returns lists of single elements for no obvious reason
+    and parse_qsl returns a list of pairs.
+    both of these suck.
+    """
+    return dict(parse_qsl(s))
+
+
+class UWProxy(requests.Session):
+    """
+    rewrite requests to go through the UW library
+    TODO: is there a better way to write this? as a python-requests plugin of some sort?
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._logged_in = False
+        self._user = None
+    
+    def login(self, last_name, card_barcode):
+        """
+        Login to the UW library proxy. That is, do this page (which you are probably familiar with): https://login.proxy.lib.uwaterloo.ca/login.
+        last_name: your "username". Note that the UW library does *not* use your Quest ID.
+        card_barcode: your "password" -- the 14 digit barcode number; not your student ID.
+        """
+        
+        try:
+            self._logged_in = "logging_in" #workaround the assert in request(). I want to keep that assert for the common case, but it breaks this initial step.
+            r = super().post("http://login/login", #this funny URL is because this call itself gets routed through the proxy hackery in self.request()
+                data={#"url": "h,
+                      #"url": "http://4chan.org",
+                        #the proxy optionally will redirect you to
+                        # https://login.proxy.lib.uwaterloo.ca/connect?session=s${SID}N&url=${URL} which, if it recognizes the site,
+                        # will redirect you to
+                        #  http://${HOST}.proxy.lib.uwaterloo.ca/${PATH} ((where ${URL} = http(s)://$HOST/$PATH))
+                        # and if it doesn't will just send you to
+                        #  $URL
+                        #
+                        # However, the library proxy doesn't care where you ask to go---you can even go off to 4chan---and it will happily hand out session cookies
+                        # So this isn't actually necessary for the sake of the scraper.
+                        # (if not given, you get sent to https://login.proxy.lib.uwaterloo.ca/menu)
+                      
+                      # credentials
+                      #yes, the UW proxy reverses the definition of 'username' and 'password':
+                      "pass": last_name,
+                      "user": card_barcode})
+            
+            r.raise_for_status() #dirty way to make sure we have 200 OK
+            SID = self.cookies["ezproxy"] #make sure that the login process appears to have given us the magic ticket
+            
+            logging.debug("Started new UW Library Proxy session '%s'" % (SID,)) #DEBUG
+            #import IPython; IPython.embed() #DEBUG
+            #logging.debug("Library proxy sent us on this goose chase:\n",
+            #      "\n->\t".join([p.url for p in r.history] + [r.url]),)
+        except Exception as exc:
+            # TODO: better exception
+            raise Exception("Failed logging in to library proxy", exc)
+        
+        # if everything is peachy, record who's account we're using
+        self._logged_in = True
+        self._user = last_name
+    
+    def request(self, verb, url, *args, **kwargs):
+        """
+        Rewrite all requests going through this session to go through the library proxy.
+        
+        Of course, the library proxy is not a standard HTTP proxy at all: it does its own thing.
+        Luckily, the protocol is pretty simple: just tack on a domain and make sure to send the right cookie.
+        """
+        assert self._logged_in == "logging_in" or self._logged_in, "Must be logged in to use the library proxy" #it will 302 to the login page if you're not; since this would be confusing when scripting, just disallow it.
+        
+        def proxyify(url):
+            scheme, host, path, params, query, fragment = urlparse(url)
+            proxy_host = host + ".proxy.lib.uwaterloo.ca"
+            return urlunparse((scheme, proxy_host, path, params, query, fragment))
+        
+        proxy_url = proxyify(url)
+        
+        # rewrite the referer to use the proxy too
+        # TODO: where else do we leak URLs?
+        if 'headers' in kwargs:
+            if 'Referer' in kwargs['headers']:
+                kwargs['headers']['Referer'] = proxyify(kwargs['headers']['Referer'])
+        
+        #*disable* SSL checking because the libary proxy has an out of date cert or something. ugh.
+        # TODO: figure out what's going on here; what if I explicitly add UW's cert to the search path (which python-requests lets me do by setting verify to a path instead of a boolean)
+        if 'verify' not in kwargs:
+            kwargs['verify'] = False 
+        return super().request(verb, proxy_url, *args, **kwargs)
+        
+
+class AnonymizedUAMixin(requests.Session):
+    """
+    a requests.Session that tweaks settings to try to anonymize some of our details,
+    just because there's no reason not to fly under the radar if we can.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.headers['User-Agent'] = self.random_UA()
+
+    @staticmethod
+    def random_UA():
+        """
+        
+        # TODO: a library that automatically downloads common user agents and picks one
+        """
+        return "Mozilla/5.0 (X11; Linux x86_64; rv:36.0) Gecko/20100101 Firefox/36.0"
+    

--- a/isi_scrape.py
+++ b/isi_scrape.py
@@ -191,9 +191,11 @@ class ISISession(requests.Session):
                       the first uses "IS" and the second "BN" to refer to ISBN, much like Harry and Draco.
                       the first doesn't list "DT" and some other fields
                       You apparently can search by anything in the fuller list, regardless.
-              - querystring is fed directly into ISI unchecked. You generally can use globbing here (*, $ ?, ...)
-                You can also (apparently) embed operator strings here.
+              - querystring is fed directly into ISI unchecked.
+                Anything you can use from the http://isiknowledge.com/wos search engine you can use here (and if things aren't working, try it via the Web UI first).
+                ~Generally~ you can use ranges ("2007-2010"), globbing (?, +, *), and boolean operators ("WOS:000348623400019 OR WOS:000348623400022") here, so long as it makes sense.
                 Reference: http://images.webofknowledge.com/WOKRS5161B5_fast5k/help/WOS/hs_search_rules.html
+                Let it be reiterated that this string is fed into ISI **UNCHECKED**, which makes it both powerful and a pain.
             - operator strings: AND, OR, NOT, NEAR, SAME; also fed into ISI unchecked.
                 Reference: http://images.webofknowledge.com/WOKRS5161B5_fast5k/help/WOS/hs_search_operators.html
             The length of fields should be an odd number because there should be exactly one less operator than query pairs.

--- a/isi_scrape.py
+++ b/isi_scrape.py
@@ -82,7 +82,7 @@ class UWProxy(requests.Session):
                       "user": card_barcode})
             
             r.raise_for_status() #dirty way to make sure we have 200 OK
-            SID = S.cookies["ezproxy"] #make sure that the login process appears to have given us the magic ticket
+            SID = self.cookies["ezproxy"] #make sure that the login process appears to have given us the magic ticket
             
             print("Started new UW Library Proxy session '%s'" % (SID,), file=sys.stderr)
             #import IPython; IPython.embed() #DEBUG

--- a/isi_scrape.py
+++ b/isi_scrape.py
@@ -70,122 +70,10 @@ from bs4 import BeautifulSoup
 # local package imports
 from isiparse import is_WOS_number
 from util import *
+from httputil import *
 
 
-#------------ utils (which aren't general enough to belong in util.py)
-
-def qs_parse(s):
-    """
-    the parse_qs in urllib returns lists of single elements for no obvious reason
-    and parse_qsl returns a list of pairs.
-    both of these suck.
-    """
-    return dict(parse_qsl(s))
-
-
-class UWProxy(requests.Session):
-    """
-    rewrite requests to go through the UW library
-    TODO: is there a better way to write this? as a python-requests plugin of some sort?
-    """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._logged_in = False
-        self._user = None
-    
-    def login(self, last_name, card_barcode):
-        """
-        Login to the UW library proxy. That is, do this page (which you are probably familiar with): https://login.proxy.lib.uwaterloo.ca/login.
-        last_name: your "username". Note that the UW library does *not* use your Quest ID.
-        card_barcode: your "password" -- the 14 digit barcode number; not your student ID.
-        """
-        
-        try:
-            self._logged_in = "logging_in" #workaround the assert in request(). I want to keep that assert for the common case, but it breaks this initial step.
-            r = super().post("http://login/login", #this funny URL is because this call itself gets routed through the proxy hackery in self.request()
-                data={#"url": "h,
-                      #"url": "http://4chan.org",
-                        #the proxy optionally will redirect you to
-                        # https://login.proxy.lib.uwaterloo.ca/connect?session=s${SID}N&url=${URL} which, if it recognizes the site,
-                        # will redirect you to
-                        #  http://${HOST}.proxy.lib.uwaterloo.ca/${PATH} ((where ${URL} = http(s)://$HOST/$PATH))
-                        # and if it doesn't will just send you to
-                        #  $URL
-                        #
-                        # However, the library proxy doesn't care where you ask to go---you can even go off to 4chan---and it will happily hand out session cookies
-                        # So this isn't actually necessary for the sake of the scraper.
-                        # (if not given, you get sent to https://login.proxy.lib.uwaterloo.ca/menu)
-                      
-                      # credentials
-                      #yes, the UW proxy reverses the definition of 'username' and 'password':
-                      "pass": last_name,
-                      "user": card_barcode})
-            
-            r.raise_for_status() #dirty way to make sure we have 200 OK
-            SID = self.cookies["ezproxy"] #make sure that the login process appears to have given us the magic ticket
-            
-            print("Started new UW Library Proxy session '%s'" % (SID,), file=sys.stderr)
-            #import IPython; IPython.embed() #DEBUG
-            #print("Library proxy sent us on this goose chase:\n",
-            #      "\n->\t".join([p.url for p in r.history] + [r.url]),
-            #      file=sys.stderr) #DEBUG
-        except Exception as exc:
-            # TODO: better exception
-            raise Exception("Failed logging in to library proxy", exc)
-        
-        # if everything is peachy, record who's account we're using
-        self._logged_in = True
-        self._user = last_name
-    
-    def request(self, verb, url, *args, **kwargs):
-        """
-        Rewrite all requests going through this session to go through the library proxy.
-        
-        Of course, the library proxy is not a standard HTTP proxy at all: it does its own thing.
-        Luckily, the protocol is pretty simple: just tack on a domain and make sure to send the right cookie.
-        """
-        assert self._logged_in == "logging_in" or self._logged_in, "Must be logged in to use the library proxy" #it will 302 to the login page if you're not; since this would be confusing when scripting, just disallow it.
-        
-        def proxyify(url):
-            scheme, host, path, params, query, fragment = urlparse(url)
-            proxy_host = host + ".proxy.lib.uwaterloo.ca"
-            return urlunparse((scheme, proxy_host, path, params, query, fragment))
-        
-        proxy_url = proxyify(url)
-        
-        # rewrite the referer to use the proxy too
-        # TODO: where else do we leak URLs?
-        if 'headers' in kwargs:
-            if 'Referer' in kwargs['headers']:
-                kwargs['headers']['Referer'] = proxyify(kwargs['headers']['Referer'])
-        
-        #*disable* SSL checking because the libary proxy has an out of date cert or something. ugh.
-        # TODO: figure out what's going on here; what if I explicitly add UW's cert to the search path (which python-requests lets me do by setting verify to a path instead of a boolean)
-        if 'verify' not in kwargs:
-            kwargs['verify'] = False 
-        return super().request(verb, proxy_url, *args, **kwargs)
-        
-
-class AnonymizedUAMixin(requests.Session):
-    """
-    a requests.Session that tweaks settings to try to anonymize some of our details,
-    just because there's no reason not to fly under the radar if we can.
-    """
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.headers['User-Agent'] = self.random_UA()
-
-    @staticmethod
-    def random_UA():
-        """
-        
-        # TODO: a library that automatically downloads common user agents and picks one
-        """
-        return "Mozilla/5.0 (X11; Linux x86_64; rv:36.0) Gecko/20100101 Firefox/36.0"
-    
-
-
-#--------------- ripper
+class ISIError(Exception): pass
 
 class ISISession(requests.Session):
     """
@@ -373,7 +261,7 @@ class ISISession(requests.Session):
         err = err.text.strip()
         if err:
             #TODO: better exception
-            raise Exception("Search failed", err)
+            raise ISIError("Search failed", err)
             
         return soup
         

--- a/isi_scrape.py
+++ b/isi_scrape.py
@@ -768,6 +768,10 @@ class ISIQuery:
                     w.write(r.text) #assuming ISI returns plain text to us. which it should. because we're telling it to.
             except HTTPError:
                 break
+    
+    def __str__(self):
+        return "<%s: %d records%s>" % (type(self).__name__, len(self), " (approximately)" if self.estimated else "") #<-- this could be better
+    
 
 def tos_warning():
     print("In using this to download records from the Web of Science, you should be aware of the terms of service:")

--- a/isi_scrape.py
+++ b/isi_scrape.py
@@ -2,13 +2,22 @@
 
 # TODO:
 # [ ] Use logging.debug() instead of print() everywhere
+# [ ] Outlinks:
+#     Using OutboundService.do with "CITREF" in filters
+#     WOS's full_record.do has a "Citation Network" div which links to
+#     InterService.do which has the export options of the regular page;
+#     indeed, clicking this makes a new qid (hidden) number.
+#     This route gives a full ISI record for each
+# [ ] Inlinks:
+#     On a query result page, the "Times Cited" links go to
+#     CitingArticles.do which provides all the inlinks.
+#     Extract these.
 
 import sys, os
 #import argparse, optparse, ...
 
-
 import locale
-from itertools import count, chain, cycle
+from itertools import count, cycle
 
 from urllib.parse import urlparse, urlunparse, quote as urlquote, parse_qsl
 import traceback
@@ -18,15 +27,10 @@ from bs4 import BeautifulSoup
 
 from warnings import warn
 
+from util import flatten
+
 
 #------------ utils
-
-def flatten(L):
-    """
-    flatten a nested list by one level
-    """
-    return list(chain.from_iterable(L))
-
 
 def qs_parse(s):
     """
@@ -426,8 +430,28 @@ class ISISession(requests.Session):
         """
         return self.generalSearch(('TS', topic))
     
+    def outlinks(self, document):
+        """
+        Given an ISI document ID (aka WOS number aka UT field aka Accession Number),
+        get an ISIQuery over all the documents it cites.
+        
+        Now, you also get outlinks this in the "CR" field, but those are badly mangled
+        MLA-esque single line citations; this API actually gives you the full records. 
+        """
+        assert is_wos_number(document)
+        raise NotImplementedError
+    
+    def inlinks(self, document):
+        """
+        Given an ISI document ID (aka WOS number aka UT field aka Accession Number),
+        get an ISIQuery over all the documents that cites it.
+        """
+        assert is_wos_number(document)
+        raise NotImplementedError
+    
     #def __str__(self):
     #    return "<%s: %s " % (type(self),) #???
+
 
 
 

--- a/isi_scrape.py
+++ b/isi_scrape.py
@@ -702,7 +702,7 @@ if __name__ == '__main__':
                   "ISI Session: %s\n"
                   "Date: %s\n" %
                   (strquery, len(Q), S._SID, datetime.datetime.now()), file=desc)
-        fname = "%s.isi" % (S._SID,) #name according to the SID; this should be redundant since we're also making a new folder *but* it will help if files get mixed together.
+        fname = "%s.ciw" % (S._SID,) #name according to the SID; this should be redundant since we're also making a new folder *but* it will help if files get mixed together.
         print("Ripping results.")
         Q.rip(fname)
     except Exception as exc:

--- a/isicount.sh
+++ b/isicount.sh
@@ -6,4 +6,4 @@
 
 # records are ended by a single code "ER" on a line by itself.
 # if we count those we count how many complete records we have.
-egrep "^ER" $@ | wc -l
+egrep "^ER" "$@" | wc -l

--- a/isijoin.sh
+++ b/isijoin.sh
@@ -8,7 +8,7 @@ echo "FN Thomson Reuters Web of Science"
 echo "VR 1.0"
 
 for fname in "${@}"; do
-  tail -n +2 "${fname}" | head -n -2
+  tail -n +3 "${fname}" | head -n -1
 done
 
 echo "EF"

--- a/isiparse.py
+++ b/isiparse.py
@@ -1,0 +1,314 @@
+"""
+ISI flat file format parser.
+
+run test(s) with
+```
+python -m isiparse path/to/data.isi
+```
+"""
+
+
+
+class EmptyModule(): pass
+
+try:
+    import builtins
+except ImportError:
+    # hack around python2/3 (in)compatibility
+    builtins = EmptyModule()
+    import codecs
+    builtins.open = codecs.open
+
+import sys
+
+from datetime import date
+import time
+from util import chomp
+
+import logging
+
+class ISIFormatError(Exception):
+  pass
+
+
+#class NumberedISIFormatError(ISIFormatError):
+#	def __init__(self, line, *args):
+#		self._line #^ this is meant to DRY up the line[%d] shit
+#		super()    # but i don't want to think about it right now
+	
+
+def strpisimonth(d, fmt):
+    """
+    parse an ISI format "date" (PD field). This sometimes doesn't exist, sometimes includes a month, and sometimes includes a day.
+  
+    Known formats:
+    Month ("%b")
+    Month Day ("%b %d")
+    Month-Month ("%b-%b") --- this gets coerced to the first %b, dropping the month range
+    Season ("%s") --- this gets coerced to use the first month of the given season
+    
+    returns just the integer month, since we aren't going to use more resolution than that since the data isn't going to give it to us
+    (this is a helper routine for parse_isi_month(); the reason it's not an inner function is poor: it's so I can instrument it with wrapper functions from external modules)
+    """
+    try:
+        # handle the extension formats by a mixture of edits to the data and to fmt
+        # then fall back on the standard strptime (whether or not we went through an extension format or not)
+        if fmt == "%b-%b":
+            # handle a month range e.g. "2006 APR-MAY"
+            # which strptime can't handle
+            l = d.find("-")
+            if not (len(d) == 3 + 1 + 3): #four chars for the year, 3 for a month, 3 for another month
+                raise ValueError("time data '%s' has wrong length for format %%b-%%b" % (d,))
+            if not (d[3] == "-"): #four chars for the year, 3 for a month, 3 for another month
+                raise ValueError("time data '%s' missing hyphen for format %%b-%%b" % (d,))
+            end_month = time.strptime(d[l+1:], "%b") #this is a no-op, but it ensures that the format looks like we think it does
+            d, fmt = d[:-4], "%b"
+        elif fmt == "%s":
+            # handle a season e.g. "FAL"
+            # remap season to a month
+            # this is a kludge, but at least it gives us *something*
+            # each season gets three months out of twelve
+            seasons = {'SPR': "MAR", 'SUM': "JUN", 'FAL': 'SEP', 'WIN': "DEC"}
+            if d in seasons:
+                d, fmt = seasons[d], "%b"
+            else:
+                raise ValueError("unknown ISI season '%s'" % (d,))
+        
+        return time.strptime(d, fmt).tm_mon
+    except ValueError:
+        # coerce any error to strptime()'s default message, to hide the real source
+        raise ValueError("time data '%s' does not match format '%s'" % (d,fmt))
+
+def parse_month(m):
+    """
+    """
+    # try all the formats, starting with the most restrictive
+    # strpisimonth requires an exact match so order shouldn't matter
+    for fmt in ["%b %d", "%b", "%b-%b", "%s"]:
+        try:
+            return strpisimonth(m, fmt) 
+        except ValueError:
+            # silence the ValueErrors from a failed strpisimonth()
+            # however if everything ValueError's out, the else clause will fire
+            #print("error parsing '%s' with format '%s'" % (d, fmt))
+            #traceback.print_exc() #DEBUG; warning: enabling this will be verrrry noisy
+            continue
+    else:
+        raise ValueError("ISI time data '%s': format unrecognized" % (d,))
+    
+    assert False, "NOTREACHED"
+
+def parse_year(year):
+    # parse out the year
+    if not isinstance(year, str):
+        raise TypeError
+    
+    if len(year) != 4:
+        raise ISIFormatError("Invalid ISI Year '%s'" % (year,))
+    try:
+        _year = int(year)
+        if not (1900 <= int(_year) <= 3000):
+            raise ValueError("year out of range")
+        return _year
+    except ValueError:
+        raise ISIFormatError("Invalid ISI Year '%s'" % (year,))
+        
+        
+
+
+def records(isi):
+	"""
+	read records from an open ISI-format file
+	
+  	TODO: make into a method on isireader()
+	"""
+	
+	if isi.encoding.lower() != "utf-8-sig":
+		logging.warn("%s opened in '%s' instead of BOM-compatible 'utf-8-sig'" % (isi, isi.encoding,))
+	
+	isi = (chomp(line) for line in isi) #(lazily) autostrip trailing newlines
+	isi = ((i+1, line) for i, line in enumerate(isi)) #number isi lines, so we can give good debugging output
+	def partition_lines(isi): #this is longer than it needs to be simply because I want to pass 'i' through it for the 'sep' error message
+				   #it would be shorter written as a simple map function, without an internal loop
+		for i, line in isi:
+			#print(i,line) #DEBUG (handy: can see *every line* go past)
+			#import IPython; IPython.embed()
+			# partition the line
+			# (note: EF, ER, and the blank line between records break the pattern, hence the verbose if chain)
+			# ( also being stateful and ordering ops choosily means we can reuse 'line' without worrying stomping it before the 'sep' check)
+			
+			if len(line) > 2:
+				sep = line[2]
+				if sep != ' ':
+					raise ISIFormatError("line[%d]: Malformed ISI line: '%r'" % (i,line))
+			tag = line[:2]
+			line = line[3:] #subtle: [3:] works even if the line is not that long, it just gives "". This is probably acceptable:
+				# on pure-tag lines like "ER" line will end up as "" as expected, and on the blank line, so will tag
+			
+			yield i, (tag, line)
+	
+	isi = partition_lines(isi)
+	
+	# ---- parse very first line
+	_, (tag, header) = next(isi)
+	if tag != 'FN':
+		raise ISIFormatError("Malformed header: '%s %s'" % (tag, header,))
+	
+	#TODO: pass the header and version upwards somehow (probably by wrapping yet another generator)
+	# TODO: handle the case where the file ends at these next()s.	
+
+	# ---- parse very second line
+	_, (tag, version) = next(isi)
+	if tag != "VR":
+			raise ISIFormatError("Malformed version '%s %s'" % (tag, version,))
+	if version != "1.0": #TODO: make this optional, via flag (yayyy feature creep)
+		raise ISIFormatError("Unsupported version '%s'" % (version,))
+	
+	
+	# ---- parse everything else
+	
+	
+	def fields():
+		"""
+		a generator over the fields in an isi record
+		each key is a two letter ISI code as at <TODO>
+		and each value is a string of everything following it, possibly on continuation lines.
+		Now, some fields are actually lists, and some are simply extended paragraphs.
+		(and some seem to be jerks that don't fit either)
+		For now, content is returned as a list of the lines, even content of only a single element,
+			either interpret beyond that should happen at a higher level or be carefully special-cased in.
+		
+		Control flow here is a bit unusual:
+		 fields() and records() work together to process *the same stream*
+		when fields() gives up on the stream, records() goes back to nomming it,
+		and usually it immediately hands control back to fields()
+		"""
+		
+		# the (apparent) format of an ISI field is:
+		# [two letter character code][single space][content][newline]([two spaces][single space][content])*
+		# that is, continuation lines are given by a two-"letter" code of '  '
+		# This is a perfectly difficult format to parse, for which a very stateful generator is a great answer.
+		
+		# output will be (field, content)
+		# except to avoid the quadradtic string-realloc curse, we store content as a list until we're done
+
+		field, content = None, None
+		
+		# short maps to convert content's output form to something resembling it's real content
+		# all fields are flattened by default unless they are explicitly listed here
+		# inferring from the data I have, *some* fields, if they overflow,
+		# are implicitly joined by newlines(?)
+		# and others by spaces
+		# and .. uh.. yeah.
+		
+		# TODO: figure out if I can assume. that abstracts do not seem to follow this convention wigs me out.
+		paragraph = lambda c: str.join("\n", c)
+		semicolon_list = lambda c: str.join(" ", c).split("; ")
+		newline_list = lambda c: c
+		flatten = lambda c: " ".join(c)
+		reformatters = {'AB': paragraph, #abstracts are just paragraphs reflowed
+			'SC': semicolon_list,  #subject categories are a a list split by semicolons
+			'WC': semicolon_list,  #ditto for web-of-science categories
+			#....			
+			'C1': newline_list,
+			#'PY': parse_year, #TODO
+			#'PD': parse_month,
+			}				
+		_outcount = 0 #DEBUG
+		for i, (tag, line) in isi:			
+			# figure out what type of line we have:
+			if tag != '  ':
+				# a new field
+				assert tag == tag.upper(), "ISI field tags should all be two letter upper case strings"
+				
+				# return what's collected (if any)
+				# putting this here is cleaner than dupeing this code above to do a do-while
+				if field is None:
+					# but only if there's anything to return, of course
+					assert content is None, "invariant: field exists <=> content exists"
+				else:
+					_outcount += 1
+					yield field, reformatters.get(field, flatten)(content)
+				
+				if tag == 'ER':
+					# end record
+					break
+				elif tag == 'EF':
+					# end file
+					assert _outcount == 0 #XXX this should be an ISIFormatError
+					return          #cut short the generator
+				else:
+					# common case: a new tag
+					# reset the accumulators and continue
+					field, content = tag, [line]
+			else:
+				# continuation line
+				if field is None:
+					raise ISIFormatError("line[%d]: Field continuation line seen before any field tag: '%s'" % (i,line,))
+				assert content is not None, "invariant: field exists <=> content exists"
+				content += [line]
+		else:
+			raise ISIFormatError("line[%d]: Record (and file) ended before 'ER' marker." % (i,))
+
+	
+	while True:
+		# read records
+		# this loop ends when we read a fake 'record' that consists of a single tag 'EF'
+		r = list(fields())
+		if not r:
+			# end of file (NB: this isn't the same as EOF, the actual file might continue)
+			break
+		
+		# sanity check
+		if len(r) != len({k for k,v in r}):
+			raise ISIFormatError('Duplicate fields seen in a record: %s' % (fields,))
+		# coerce to dict form, now that we know it's safe
+		yield dict(r)
+		
+		# every record is followed by a single empty line
+		# TODO: maybe just scrap this; how important is it really to enforce the BLANK LINE RULE? seriously. autists ehre we come.
+		try:
+			i, blank = next(isi)
+			if blank != ("",""):
+				raise ISIFormatError("line[%d]: Missing blank line after record. Instead saw: %s" % (i, blank))
+		except StopIteration:
+			raise ISIFormatError("File ended before 'EF' marker.") #XXX awkward; DRY this with the one below
+	else:
+		# ensure that we exit the loop by 'EF' and not some other way
+		raise ISIFormatError("File ended before 'EF' marker.")
+	
+
+
+class reader():
+	def __init__(self, name, encoding="utf-8-sig"):
+		self._file = builtins.open(name, "r", encoding=encoding)
+	
+	def __iter__(self):
+		return iter(records(self._file))
+	
+	def __enter__(self):
+		assert not self._file.closed
+		return self
+		
+	def __exit__(self, *_unused):
+		self._file.close()
+
+
+def open(fname, mode="r", encoding="utf-8-sig"):
+	"""
+	utf-8-sig is the most widely compatible text codec. It handles both ASCII files (because of utf-8 backwards compatibility) and most Unicode files, with or without a BOM.
+	If you happen to have a different encoding, you can provide it. See the codecs module for options.
+	TODO: use the chardet module?
+	"""
+	if mode != "r":
+		raise NotImplementedError("only have read-only support so far")
+	
+	return reader(fname)
+
+if __name__ == '__main__':
+	import sys
+	with open(sys.argv[1]) as isi:
+		for i, record in enumerate(isi):
+			print(i, record)
+			#import IPython; IPython.embed()
+	

--- a/isiparse.py
+++ b/isiparse.py
@@ -12,6 +12,22 @@ python -m isiparse path/to/data.isi
 #     I *thought* the PD field was only ever month and maybe day, but sometimes it duplicates the year (PY) field too
 #     Once this works, write an assertion "not ('PY' in fields and 'PD' in fields and fields['PD'].year is not None) or (fields['PY'] == fields['PD'].year)
 
+
+def is_WOS_number(w):
+    """
+    check that the string w is a WOS number
+    You find these in the 'UT' field in exported .isi files.
+    It is also called the "Accession Number" 
+    """
+    try:
+        header, number = w[:4], w[4:]
+        assert header == "WOS:"
+        assert len(number) == 15
+        assert all(int(e) for e in number))
+    except: #<-- ugh, lazy
+        return False
+
+
 class EmptyModule(): pass
 
 try:

--- a/isiparse.py
+++ b/isiparse.py
@@ -26,6 +26,8 @@ def is_WOS_number(w):
         assert all(int(e) for e in number))
     except: #<-- ugh, lazy
         return False
+    
+    return True
 
 
 class EmptyModule(): pass

--- a/isiparse.py
+++ b/isiparse.py
@@ -1,9 +1,15 @@
 """
 ISI flat file format parser.
 
-run test(s) with
+Empirically, the ISI flat file format is *identical* to the plain text
+EndNote format (.ciw), judging from what happens when you export from
+the Thomson-Reuters Web of Science "To EndNote Desktop" vs "To Other
+Reference Software". The only difference might be the file extension.
+
+Run test(s) by getting a .ciw file either
+manually or with isi_scrape and running
 ```
-python -m isiparse path/to/data.isi
+python -m isiparse data.ciw
 ```
 """
 

--- a/isiparse.py
+++ b/isiparse.py
@@ -24,12 +24,13 @@ def is_WOS_number(w):
     check that the string w is a WOS number
     You find these in the 'UT' field in exported .isi files.
     It is also called the "Accession Number"
+    
+    The format of this is "WOS:ddddddddddddddd": the 'd's are usually digits, but sometimes they are capital letters; sometimes they encode dates in them, and sometimes they seem totally arbitrary.
     """
     try:
         header, number = w[:4], w[4:]
         assert header == "WOS:"
         assert len(number) == 15
-        assert all(int(e) for e in number))
     except: #<-- ugh, lazy
         return False
     

--- a/isiparse.py
+++ b/isiparse.py
@@ -17,13 +17,13 @@ python -m isiparse data.ciw
 # [ ] rework strpisimonth to be strpisidate, returning a tuple instead of an integer;
 #     I *thought* the PD field was only ever month and maybe day, but sometimes it duplicates the year (PY) field too
 #     Once this works, write an assertion "not ('PY' in fields and 'PD' in fields and fields['PD'].year is not None) or (fields['PY'] == fields['PD'].year)
-
+# [ ] Rename this whole thing to ciwparse? EndNoteParse (though this might get us sued :P)?
 
 def is_WOS_number(w):
     """
     check that the string w is a WOS number
     You find these in the 'UT' field in exported .isi files.
-    It is also called the "Accession Number" 
+    It is also called the "Accession Number"
     """
     try:
         header, number = w[:4], w[4:]

--- a/papers.py
+++ b/papers.py
@@ -28,7 +28,7 @@ def isiParser(isifile):
     """
     f = open(isifile, 'r')
     if "VR 1.0" not in f.readline() and "VR 1.0" not in f.readline():
-        raise BadPaper(file + " Does not have a valid header")
+        raise BadPaper(isifile + " Does not have a valid header")
     notEnd = True
     plst = []
     while notEnd:

--- a/papers.py
+++ b/papers.py
@@ -1,0 +1,59 @@
+class BadPaper(Warning):
+    pass
+
+def paperParser(paper):
+    """
+    paperParser reads paper until it reaches 'EF' for each field tag it adds an
+    entry to the returned dict with the tag as the key and a list of the entries
+    for the tag as the value, the list has each line as an entry.   
+    """
+    tdict = {}
+    currentTag = ''
+    for l in paper:
+        if 'ER' in l[:2]:
+            return tdict
+        elif '   ' in l[:3]: #the string is three spaces in row
+            tdict[currentTag].append(l[3:-1])
+        elif l[2] == ' ':
+            currentTag = l[:2]
+            tdict[currentTag] = [l[3:-1]]
+        else:
+            raise BadPaper("Field tag not formed correctly: " + l)
+    raise BadPaper("End of file reached before EF")
+
+def isiParser(isifile):
+    """
+    isiParser reads a file, checks that the header is correct then reads each
+    paper returning a list of of dicts keyed with the field tags.
+    """
+    f = open(isifile, 'r')
+    if "VR 1.0" not in f.readline() and "VR 1.0" not in f.readline():
+        raise BadPaper(file + " Does not have a valid header")
+    notEnd = True
+    plst = []
+    while notEnd:
+        l = f.next()
+        if not l:
+            raise BadPaper("No ER found in " + isifile)
+        elif l.isspace():
+            continue
+        elif 'EF' in l[:2]:
+            notEnd = False
+            continue
+        else:
+            try:
+                if l[:2] != 'PT':
+                    raise BadPaper("Paper does not start with PT tag")
+                plst.append(paperParser(f))
+                plst[-1][l[:2]] = l[3:-1]
+            except Warning as w:
+                raise BadPaper(str(w.message) + "In " + isifile)
+            except Exception as e:
+                 raise e
+    try:
+        f.next()
+        print "EF not at end of " + isifile
+    except StopIteration as e:
+        pass
+    finally:
+        return plst

--- a/util.py
+++ b/util.py
@@ -1,0 +1,23 @@
+
+def list_ret(g):
+    """
+    flatten a generator to a list, and additionally return its return value (which will be None if there isn't one and/or if g isn't actually a generator)
+    returns: (list(g), return_value)
+    
+    TODO: is this in stdlib somewhere?
+    """
+    L = []
+    while True:
+        try:
+            L.append(next(g))
+        except StopIteration as stop:
+            return L, stop.value
+            
+            
+            
+def chomp(s):
+	"remove trailing newline"
+	"assumes universal newlines mode "
+	if s.endswith("\n"): s = s[:-1]
+	return s
+	

--- a/util.py
+++ b/util.py
@@ -31,3 +31,12 @@ def flatten(L):
     """
     return list(chain.from_iterable(L))
 
+
+def parse_american_int(c):
+    """
+    Parse an integer, possibly an American-style comma-separated integer.
+    """
+    if not isinstance(c, str):
+        raise TypeError
+    #dirty hack; also what SO decided on: http://stackoverflow.com/questions/2953746/python-parse-comma-separated-number-into-int
+    return int(c.replace(",",""))

--- a/util.py
+++ b/util.py
@@ -1,8 +1,12 @@
 
+from itertools import chain
+
 def list_ret(g):
     """
-    flatten a generator to a list, and additionally return its return value (which will be None if there isn't one and/or if g isn't actually a generator)
+    Exhaust a generator to a list, and additionally return its return value which normally you need to catch in an exception handler.
     returns: (list(g), return_value)
+    
+    As with regular functions, return_value will be None if there isn't one and/or if g isn't actually a generator.
     
     TODO: is this in stdlib somewhere?
     """
@@ -12,8 +16,7 @@ def list_ret(g):
             L.append(next(g))
         except StopIteration as stop:
             return L, stop.value
-            
-            
+
             
 def chomp(s):
 	"remove trailing newline"
@@ -21,3 +24,10 @@ def chomp(s):
 	if s.endswith("\n"): s = s[:-1]
 	return s
 	
+	
+def flatten(L):
+    """
+    flatten a nested list by one level
+    """
+    return list(chain.from_iterable(L))
+


### PR DESCRIPTION
There is now an API to scrape both the citations by and citations of a given WOS number.

inlinks() seems to work a lot better in practice, because outlinks() just calls ISI's site, which does something like taking the list you get in the CR field, and not all of those references are resolvable because they might be old, badly formatted, or in a different database.